### PR TITLE
Switch to using `webimpress/safe-writer`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,36 +12,24 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: 5.6
+    - php: 7.2
       env:
         - DEPS=latest
-    - php: 7
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
+    - php: 7.4
       env:
         - DEPS=latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,24 +12,36 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 5.6
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 5.6
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: 7
       env:
         - DEPS=lowest
-    - php: 7.3
+    - php: 7
+      env:
+        - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.4
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: 7.4
+    - php: 7.2
+      env:
+        - DEPS=latest
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^5.6 || ^7.0",
         "laminas/laminas-stdlib": "^2.7.7 || ^3.1.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
-        "webimpress/safe-writer": "^1.0.1 || ^2.0"
+        "webimpress/safe-writer": "^1.0.2 || ^2.0.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^5.6 || ^7.0",
         "laminas/laminas-stdlib": "^2.7.7 || ^3.1.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
-        "webimpress/safe-writer": "^1.0"
+        "webimpress/safe-writer": "^1.0.1 || ^2.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "laminas/laminas-stdlib": "^2.7.7 || ^3.1.0",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-zendframework-bridge": "^1.0",
+        "webimpress/safe-writer": "^2.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^5.6 || ^7.0",
         "laminas/laminas-stdlib": "^2.7.7 || ^3.1.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
-        "webimpress/safe-writer": "^2.0"
+        "webimpress/safe-writer": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "laminas/laminas-stdlib": "^2.7.7 || ^3.1.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "webimpress/safe-writer": "^2.0"

--- a/src/ConfigAggregator.php
+++ b/src/ConfigAggregator.php
@@ -329,12 +329,6 @@ EOT;
      */
     private function writeCache($cachedConfigFile, $contents, $mode)
     {
-        // Suppresses notice when FileWriter falls back to system temp dir
-        // This can be removed if https://github.com/webimpress/safe-writer/pull/6 is merged
-        set_error_handler(function ($errno, $errstr) {
-            return strpos('tempnam():', $errstr) !== 0;
-        }, E_NOTICE);
-
         try {
             if ($mode !== null) {
                 FileWriter::writeFile($cachedConfigFile, $contents, $mode);
@@ -344,7 +338,5 @@ EOT;
         } catch (FileWriterException $e) {
             // ignore errors writing cache file
         }
-
-        restore_error_handler();
     }
 }

--- a/src/ConfigAggregator.php
+++ b/src/ConfigAggregator.php
@@ -12,8 +12,8 @@ use Closure;
 use Generator;
 use Laminas\Stdlib\ArrayUtils\MergeRemoveKey;
 use Laminas\Stdlib\ArrayUtils\MergeReplaceKeyInterface;
-
 use Webimpress\SafeWriter\FileWriter;
+
 use function array_key_exists;
 use function class_exists;
 use function date;

--- a/test/ConfigAggregatorTest.php
+++ b/test/ConfigAggregatorTest.php
@@ -125,11 +125,14 @@ class ConfigAggregatorTest extends TestCase
     {
         $this->expectException(RenameException::class);
         chmod(dirname($this->cacheFile), 0400);
-        new ConfigAggregator([
-            function () {
-                return ['foo' => 'bar', ConfigAggregator::ENABLE_CACHE => true];
-            }
-        ], $this->cacheFile);
+        $suppressNotice = function () {
+            new ConfigAggregator([
+                function () {
+                    return ['foo' => 'bar', ConfigAggregator::ENABLE_CACHE => true];
+                }
+            ], $this->cacheFile);
+        };
+        @$suppressNotice(); // suppress "file created in the system's temporary directory"
     }
 
     public function testConfigAggregatorCanLoadConfigFromCache()

--- a/test/ConfigAggregatorTest.php
+++ b/test/ConfigAggregatorTest.php
@@ -17,7 +17,6 @@ use LaminasTest\ConfigAggregator\Resources\FooPostProcessor;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-use Webimpress\SafeWriter\Exception\RenameException;
 use function file_exists;
 use function var_export;
 
@@ -121,18 +120,16 @@ class ConfigAggregatorTest extends TestCase
         $this->assertEquals(0600, fileperms($this->cacheFile) & 0777);
     }
 
-    public function testConfigAggregatorThrowsExceptionOnUnwritableCache()
+    public function testConfigAggregatorSetsHandlesUnwritableCache()
     {
-        $this->expectException(RenameException::class);
         chmod(dirname($this->cacheFile), 0400);
-        $suppressNotice = function () {
-            new ConfigAggregator([
-                function () {
-                    return ['foo' => 'bar', ConfigAggregator::ENABLE_CACHE => true];
-                }
-            ], $this->cacheFile);
-        };
-        @$suppressNotice(); // suppress "file created in the system's temporary directory"
+        new ConfigAggregator([
+            function () {
+                return ['foo' => 'bar', ConfigAggregator::ENABLE_CACHE => true];
+            }
+        ], $this->cacheFile);
+
+        $this->assertFalse(file_exists($this->cacheFile));
     }
 
     public function testConfigAggregatorCanLoadConfigFromCache()


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

This PR is an alternative to #3. As suggested by @michalbundyra it uses https://github.com/webimpress/safe-writer for writing the cache, addressing the Windows problems reported in #2 

`webimpress/safe-writer` has a minimum PHP version of 7.2, so I've bumped the minimum version of this to 7.2 as well, and added 7.4 to `.travis.yml`. Hope that's OK. 

