### PR TITLE
Allow to pass an `iterable` of config providers to the `ConfigAggregator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- `Laminas\ConfigAggregator\ConfigAggregator` now accepts any iterable type for $providers constructor argument.
 
 ### Deprecated
 

--- a/src/ConfigAggregator.php
+++ b/src/ConfigAggregator.php
@@ -59,7 +59,7 @@ EOT;
     private $config;
 
     /**
-     * @param array $providers Array of providers. These may be callables, or
+     * @param iterable $providers Array or \Iterator of providers. These may be callables, or
      *     string values representing classes that act as providers. If the
      *     latter, they must be instantiable without constructor arguments.
      * @param null|string $cachedConfigFile Configuration cache file; config is
@@ -70,7 +70,7 @@ EOT;
      *     latter, they must be instantiable without constructor arguments.
      */
     public function __construct(
-        array $providers = [],
+        iterable $providers = [],
         $cachedConfigFile = null,
         array $postProcessors = []
     ) {
@@ -217,10 +217,10 @@ EOT;
     /**
      * Iterate providers, merging config from each with the previous.
      *
-     * @param array $providers
+     * @param iterable $providers
      * @return array
      */
-    private function loadConfigFromProviders(array $providers): array
+    private function loadConfigFromProviders(iterable $providers): array
     {
         $mergedConfig = [];
         foreach ($providers as $provider) {

--- a/test/ConfigAggregatorTest.php
+++ b/test/ConfigAggregatorTest.php
@@ -52,9 +52,17 @@ class ConfigAggregatorTest extends TestCase
         new ConfigAggregator([stdClass::class]);
     }
 
-    public function testConfigAggregatorMergesConfigFromProviders(): void
+    public function testConfigAggregatorMergesConfigFromArrayProviders(): void
     {
         $aggregator = new ConfigAggregator([FooConfigProvider::class, BarConfigProvider::class]);
+        $config = $aggregator->getMergedConfig();
+        self::assertSame(['foo' => 'bar', 'bar' => 'bat'], $config);
+    }
+
+    public function testConfigAggregatorMergesConfigFromIteratorProvider(): void
+    {
+        $providers  = new \ArrayIterator([FooConfigProvider::class, BarConfigProvider::class]);
+        $aggregator = new ConfigAggregator($providers);
         $config = $aggregator->getMergedConfig();
         self::assertSame(['foo' => 'bar', 'bar' => 'bat'], $config);
     }

--- a/test/ConfigAggregatorTest.php
+++ b/test/ConfigAggregatorTest.php
@@ -8,6 +8,7 @@
 
 namespace LaminasTest\ConfigAggregator;
 
+use Iterator;
 use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ConfigAggregator\ConfigCannotBeCachedException;
 use Laminas\ConfigAggregator\InvalidConfigProcessorException;
@@ -61,7 +62,17 @@ class ConfigAggregatorTest extends TestCase
 
     public function testConfigAggregatorMergesConfigFromIteratorProvider(): void
     {
-        $providers  = new \ArrayIterator([FooConfigProvider::class, BarConfigProvider::class]);
+        $providers = $this->createMock(Iterator::class);
+        $providers
+            ->expects($this->exactly(2))
+            ->method('current')
+            ->willReturnOnConsecutiveCalls(FooConfigProvider::class, BarConfigProvider::class);
+
+        $providers
+            ->expects($this->exactly(3))
+            ->method('valid')
+            ->willReturnOnConsecutiveCalls(true, true, false);
+
         $aggregator = new ConfigAggregator($providers);
         $config = $aggregator->getMergedConfig();
         self::assertSame(['foo' => 'bar', 'bar' => 'bat'], $config);

--- a/test/ConfigAggregatorTest.php
+++ b/test/ConfigAggregatorTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\ConfigAggregator;
 
 use Iterator;
+use IteratorAggregate;
 use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ConfigAggregator\ConfigCannotBeCachedException;
 use Laminas\ConfigAggregator\InvalidConfigProcessorException;
@@ -72,6 +73,32 @@ class ConfigAggregatorTest extends TestCase
             ->expects($this->exactly(3))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, true, false);
+
+        $aggregator = new ConfigAggregator($providers);
+        $config = $aggregator->getMergedConfig();
+        self::assertSame(['foo' => 'bar', 'bar' => 'bat'], $config);
+    }
+
+    public function testConfigAggregatorMergesConfigFromIteratorAggregateProvider(): void
+    {
+        $providers = $this->createMock(IteratorAggregate::class);
+        $iterator  = $this->createMock(Iterator::class);
+
+        $providers
+            ->expects($this->once())
+            ->method('getIterator')
+            ->willReturn($iterator);
+
+        $iterator
+            ->expects($this->exactly(2))
+            ->method('current')
+            ->willReturnOnConsecutiveCalls(FooConfigProvider::class, BarConfigProvider::class);
+
+        $iterator
+            ->expects($this->exactly(3))
+            ->method('valid')
+            ->willReturnOnConsecutiveCalls(true, true, false);
+
 
         $aggregator = new ConfigAggregator($providers);
         $config = $aggregator->getMergedConfig();


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR extends typhint against providers collection types from `array` to `iterable` [pseudo-type](https://www.php.net/manual/en/language.types.iterable.php) for `Laminas\ConfigAggregator\ConfigAggregator`.

#### Why should it be added?

It open more ways to manage how configuration is assembled, without compromising the existing code.
Motivations are very mezzio framework related 😄 .

Below an attempt to explain why it should be added with the use case behind this PR.

By providing an \Iterator instead of array, we are able to lazy instantiate / register providers during bootstrap, but also implement custom logic on how parts of configuration are loaded without extra cost.

That means when the configuration cache is generated, we dont have to bootstrap useless objects.

The mezzio-skeleton config.php file can helps to illustrate the point:

```php
<?php
$aggregator = new ConfigAggregator([
    \Mezzio\Router\FastRouteRouter\ConfigProvider::class,
    \Laminas\HttpHandlerRunner\ConfigProvider::class,
    new ArrayProvider($cacheConfig),
    \Mezzio\Helper\ConfigProvider::class,
    \Mezzio\ConfigProvider::class,
    \Mezzio\Router\ConfigProvider::class,
    \Laminas\Diactoros\ConfigProvider::class,
    class_exists(\Mezzio\Swoole\ConfigProvider::class)
        ? \Mezzio\Swoole\ConfigProvider::class
        : function(): array { return[]; },
    App\ConfigProvider::class,
    new PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
    new PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
], $cacheConfig['config_cache_path']);
```

So, in production, it always (even with cache enabled): 

- Create 3 provider objects (PhpFileProvider, ArrayProvider)
- Check against the autoloader with `class_exists` if we need to register swoole
- Build the array

Its not a big deal, but for larges projects with some extra logic (as we have to deal with 😄  ) it can be better to not waste time here when the cache is already generated. 

I'm aware that the aggregator accepts registering callback individually, but using them instead of `new` does not bring obvious benefits .

So with support for \Iterator, an example of how it can be handled with a single \Generator;

```php
<?php
$providers = function(array $cacheConfig) {
    yield \Mezzio\Router\FastRouteRouter\ConfigProvider::class;
    yield \Laminas\HttpHandlerRunner\ConfigProvider::class;
    yield new ArrayProvider($cacheConfig);
    yield \Mezzio\Helper\ConfigProvider::class;
    yield \Mezzio\ConfigProvider::class;
    yield \Mezzio\Router\ConfigProvider::class;
    yield \Laminas\Diactoros\ConfigProvider::class;

    if (class_exists(\Mezzio\Swoole\ConfigProvider::class)) {
        yield \Mezzio\Swoole\ConfigProvider::class;
    }

    yield App\ConfigProvider::class;
    yield new PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php');
    yield new PhpFileProvider(realpath(__DIR__) . '/development.config.php');
};

$aggregator = new ConfigAggregator(
    $providers($cacheConfig),
    $cacheConfig['config_cache_path']
);
```

Hope the example is clear enought !
