### PR TITLE
Apply PHP 7.4 syntax and typed property

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -78,8 +78,8 @@
       <code>$input</code>
       <code>$input</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1">
-      <code>function ($input) use ($prefix) {</code>
+    <MissingClosureReturnType occurrences="2">
+      <code>static fn($input)</code>
     </MissingClosureReturnType>
     <MixedArgument occurrences="1">
       <code>$input</code>

--- a/src/ArrayProvider.php
+++ b/src/ArrayProvider.php
@@ -15,7 +15,7 @@ namespace Laminas\ConfigAggregator;
 class ArrayProvider
 {
     /** @var array<TKey, TValue> */
-    private $config;
+    private array $config;
 
     /**
      * @param array<TKey, TValue> $config

--- a/src/ConfigAggregator.php
+++ b/src/ConfigAggregator.php
@@ -49,8 +49,7 @@ class ConfigAggregator
 
 EOT;
 
-    /** @var array */
-    private $config;
+    private array $config;
 
     /**
      * @param iterable $providers Array or \Iterator of providers. These may be callables, or

--- a/src/LaminasConfigProvider.php
+++ b/src/LaminasConfigProvider.php
@@ -14,8 +14,7 @@ class LaminasConfigProvider
 {
     use GlobTrait;
 
-    /** @var string */
-    private $pattern;
+    private string $pattern;
 
     /**
      * @param string $pattern Glob pattern.

--- a/src/PhpFileProvider.php
+++ b/src/PhpFileProvider.php
@@ -13,8 +13,7 @@ class PhpFileProvider
 {
     use GlobTrait;
 
-    /** @var string */
-    private $pattern;
+    private string $pattern;
 
     /**
      * @param string $pattern A glob pattern by which to look up config files.


### PR DESCRIPTION
Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Since composer.json require php 7.4, php 7.4 syntax can be applied with typed properties. 

- For `final class`, typed properties for protected is allowed if no inherit of parent or used by its final class parent.
- Otherwise, update only private properties.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
