### PR TITLE
Add support for `brick/varexporter` 0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "extra": {},
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "brick/varexporter": "^0.4.0",
+        "brick/varexporter": "^0.5.0 || ^0.4.0",
         "laminas/laminas-stdlib": "^3.18.0",
         "webimpress/safe-writer": "^2.2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef647299c1022a669ab074bbcb3686ec",
+    "content-hash": "f2f2d4684b03db164d1bf498f6f1f4ea",
     "packages": [
         {
             "name": "brick/varexporter",


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR adds support for `brick/varexporter` v0.5.0, which in turn supports `nikic/PHP-Parser` 5, enabling upgrades to PHPUnit 11 in downstream projects.