### PR TITLE
Add support for PHP 8.4

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,7 +1,6 @@
 {
     "ignore_php_platform_requirements": {
-        "8.2": false,
-        "8.3": false
+        "8.4": true
     },
     "backwardCompatibilityCheck": true
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "extra": {},
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "brick/varexporter": "^0.5.0 || ^0.4.0",
         "laminas/laminas-stdlib": "^3.18.0",
         "webimpress/safe-writer": "^2.2.0"
@@ -34,7 +34,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.0.0",
         "laminas/laminas-config": "^3.9.0",
-        "phpunit/phpunit": "^10.5.11",
+        "phpunit/phpunit": "^10.5.38",
         "psalm/plugin-phpunit": "^0.19.0",
         "vimeo/psalm": "^5.22.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb704b9953e96a1d98bc69a904cd7ecd",
+    "content-hash": "6795166884e637a5bb6ada4443096f23",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -4289,7 +4289,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
     },
     "platform-dev": {},
     "platform-overrides": {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This PR brings support for PHP 8.4 to this library.
