### PR TITLE
allow newer varexporter version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "extra": {},
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-        "brick/varexporter": "^0.5.0 || ^0.4.0",
+        "brick/varexporter": "^0.6.0 || ^0.5.0 || ^0.4.0",
         "laminas/laminas-stdlib": "^3.18.0",
         "webimpress/safe-writer": "^2.2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6795166884e637a5bb6ada4443096f23",
+    "content-hash": "412d37bf3c6a1f0344e2203be2c0e352",
     "packages": [
         {
             "name": "brick/varexporter",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

New version of brick/varexporter is released because the previous version used an old php parser syntax. Therefore closures with match statements does not work. 
